### PR TITLE
Studentify to root

### DIFF
--- a/course-management.conf
+++ b/course-management.conf
@@ -3,7 +3,7 @@ cmt {
   main-repo-exercise-folder = exercises
 
   # Folder in studentified repo holding the current exercise code
-  studentified-repo-active-exercise-folder = code
+  studentified-repo-active-exercise-folder = .
 
   # List of folders containing test code
   test-code-folders = [


### PR DESCRIPTION
The "studentified" artefact will have the exercise code in its root folder instead of a subfolder, which should make things more intuitive for the students.