### PR TITLE
Bump sbt vedrsion

### DIFF
--- a/code-snippets/project/build.properties
+++ b/code-snippets/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.4

--- a/exercises/exercise_000_sudoku_solver_initial_state/project/build.properties
+++ b/exercises/exercise_000_sudoku_solver_initial_state/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_001_dotty_deprecated_syntax_rewriting/project/build.properties
+++ b/exercises/exercise_001_dotty_deprecated_syntax_rewriting/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/project/build.properties
+++ b/exercises/exercise_002_dotty_new_syntax_and_indentation_based_syntax/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_003_top_level_definitions/project/build.properties
+++ b/exercises/exercise_003_top_level_definitions/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_004_parameter_untupling/project/build.properties
+++ b/exercises/exercise_004_parameter_untupling/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_005_extension_methods/project/build.properties
+++ b/exercises/exercise_005_extension_methods/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_006_using_and_summon/project/build.properties
+++ b/exercises/exercise_006_using_and_summon/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_007_givens/project/build.properties
+++ b/exercises/exercise_007_givens/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_008_enum_and_export/project/build.properties
+++ b/exercises/exercise_008_enum_and_export/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_009_union_types/project/build.properties
+++ b/exercises/exercise_009_union_types/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_010_opaque_type_aliases/project/build.properties
+++ b/exercises/exercise_010_opaque_type_aliases/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_011_multiversal_equality/project/build.properties
+++ b/exercises/exercise_011_multiversal_equality/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_020_opaque_type_aliases_alt/project/build.properties
+++ b/exercises/exercise_020_opaque_type_aliases_alt/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4

--- a/exercises/exercise_021_multiversal_equality/project/build.properties
+++ b/exercises/exercise_021_multiversal_equality/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.3
+sbt.version=1.9.4


### PR DESCRIPTION
- Bump sbt to 1.9.4
- Fixes [CVE-2022-46751](https://github.com/advisories/GHSA-2jc4-r94c-rp7h)